### PR TITLE
Gas price extrapolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ The `URLS`, `FIELDS`, and `WEI` environment variables need to use the same index
     - Default value: `1000000000`
 - `MAX_GAS_PRICE`: The maximum gas price to send to the node if the data feeds respond with a higher value.
     - Default value: `1000000000000`
+- `EXTRAPOLATION_HISTORY`: The number of most recent readings used to predict and lead upward spikes in gas price. Lower is more responsive.
+    - Default value: `3`
+    - Minimum value: `2`
 - `LOG_LEVEL`: The log level for the output.
     - Default value: `'info'`
 - `CRON_SCHEDULE`: The Cron schedule to use for updating gas prices (6 places)

--- a/app.js
+++ b/app.js
@@ -26,7 +26,7 @@ cron.schedule(config.schedule, async () => {
       const currentGasPrice = await createRequests(config.details)
       gasPriceHistory.push(currentGasPrice)
       gasPriceHistory = gasPriceHistory.slice(
-        Math.max(gasPriceHistory.length - config.details.extrapolationDatasetSize, 0)
+        Math.max(gasPriceHistory.length - config.details.extrapolationHistory, 0)
         )
       const extrapolatedGasPrice = extrapolate(gasPriceHistory)
       const gasPrice = Math.max(currentGasPrice, extrapolatedGasPrice)

--- a/app.js
+++ b/app.js
@@ -27,7 +27,7 @@ cron.schedule(config.schedule, async () => {
       gasPriceHistory.push(currentGasPrice)
       gasPriceHistory = gasPriceHistory.slice(
         Math.max(gasPriceHistory.length - config.details.extrapolationHistory, 0)
-        )
+      )
       const extrapolatedGasPrice = extrapolate(gasPriceHistory)
       const gasPrice = Math.max(currentGasPrice, extrapolatedGasPrice)
       await updateChainlinkGasPrice(config.chainlink.url, cookie, gasPrice)

--- a/config.js
+++ b/config.js
@@ -11,7 +11,8 @@ const config = {
     wei: process.env.WEI || '100000000,1000000000,1000000000,1000000000',
     fallbackGasPrice: process.env.FALLBACK_GAS_PRICE || 25000000000,
     addedGasPrice: process.env.ADD_GAS_PRICE || 1000000000,
-    maxGasPrice: process.env.MAX_GAS_PRICE || 1000000000000
+    maxGasPrice: process.env.MAX_GAS_PRICE || 1000000000000,
+    extrapolationDatasetSize: process.env.EXTRAPOLATION_DATASET_SIZE || 3
   },
   schedule: process.env.CRON_SCHEDULE || '0 * * * * *'
 }

--- a/config.js
+++ b/config.js
@@ -12,7 +12,7 @@ const config = {
     fallbackGasPrice: process.env.FALLBACK_GAS_PRICE || 25000000000,
     addedGasPrice: process.env.ADD_GAS_PRICE || 1000000000,
     maxGasPrice: process.env.MAX_GAS_PRICE || 1000000000000,
-    extrapolationDatasetSize: process.env.EXTRAPOLATION_DATASET_SIZE || 3
+    extrapolationHistory: process.env.EXTRAPOLATION_HISTORY || 3
   },
   schedule: process.env.CRON_SCHEDULE || '0 * * * * *'
 }

--- a/extrapolator.js
+++ b/extrapolator.js
@@ -1,0 +1,22 @@
+const extrapolate = (ys) => {
+  if (ys.length === 0) {
+    throw new Error('Attempted to extrapolate with no data points');
+  } else if (ys.length === 1) {
+    return ys[0]
+  }
+
+  const n = ys.length
+  const xs = Array.from(Array(n).keys())
+
+  // Calculate the slope with least squares
+  // https://en.wikipedia.org/wiki/Simple_linear_regression#Numerical_example
+  const Sx = xs.reduce((a, b) => a + b, 0)
+  const Sy = ys.reduce((a, b) => a + b, 0)
+  const Sxx = xs.reduce((a, b) => a + b * b, 0)
+  const Sxy = ys.reduce((a, b, i) => a + b * xs[i], 0)
+  const slope = (n * Sxy - Sx * Sy) / (n * Sxx - Sx * Sx)
+
+  return ys[n - 1] + slope;
+}
+
+exports.extrapolate = extrapolate

--- a/extrapolator.js
+++ b/extrapolator.js
@@ -1,6 +1,6 @@
 const extrapolate = (ys) => {
   if (ys.length === 0) {
-    throw new Error('Attempted to extrapolate with no data points');
+    throw new Error('Attempted to extrapolate with no data points')
   } else if (ys.length === 1) {
     return ys[0]
   }
@@ -16,7 +16,7 @@ const extrapolate = (ys) => {
   const Sxy = ys.reduce((a, b, i) => a + b * xs[i], 0)
   const slope = (n * Sxy - Sx * Sy) / (n * Sxx - Sx * Sx)
 
-  return ys[n - 1] + slope;
+  return ys[n - 1] + slope
 }
 
 exports.extrapolate = extrapolate

--- a/extrapolator.js
+++ b/extrapolator.js
@@ -1,4 +1,14 @@
-const extrapolate = (ys) => {
+let gasPriceHistory = []
+
+const extrapolate = (details, currentGasPrice) => {
+  gasPriceHistory.push(currentGasPrice)
+  gasPriceHistory = gasPriceHistory.slice(
+    Math.max(gasPriceHistory.length - details.extrapolationHistory, 0)
+  )
+  return calculate(gasPriceHistory)
+}
+
+const calculate = (ys) => {
   if (ys.length === 0) {
     throw new Error('Attempted to extrapolate with no data points')
   } else if (ys.length === 1) {

--- a/test/extrapolator_test.js
+++ b/test/extrapolator_test.js
@@ -1,0 +1,39 @@
+const assert = require('chai').assert
+const extrapolate = require('../extrapolator').extrapolate
+
+describe('extrapolate', () => {
+  context('when history is empty', () => {
+    const gasPriceHistory = []
+    it('throws', () => {
+      try {
+        extrapolate(gasPriceHistory)
+      } catch (error) {
+        assert.equal(error.message, 'Attempted to extrapolate with no data points')
+      }
+    })
+  })
+
+  context('when history has only one data point', async () => {
+    const gasPriceHistory = [10 * 10**9]
+    it('returns that one data point', async () => {
+      const extrapolatedGasPrice = extrapolate(gasPriceHistory)
+      assert.equal(extrapolatedGasPrice, gasPriceHistory[0])
+    })
+  })
+
+  context('when there are increasing data points', () => {
+    const gasPriceHistory = [10 * 10**9, 12 * 10**9, 14 * 10**9]
+    it('extrapolates correctly', () => {
+        const extrapolatedGasPrice = extrapolate(gasPriceHistory)
+        assert.equal(extrapolatedGasPrice, 16 * 10**9)
+    })
+  })
+
+  context('when there are decreasing data points', () => {
+    const gasPriceHistory = [14 * 10**9, 12 * 10**9, 10 * 10**9]
+    it('extrapolates correctly', () => {
+        const extrapolatedGasPrice = extrapolate(gasPriceHistory)
+        assert.equal(extrapolatedGasPrice, 8 * 10**9)
+    })
+  })
+})

--- a/test/extrapolator_test.js
+++ b/test/extrapolator_test.js
@@ -2,38 +2,30 @@ const assert = require('chai').assert
 const extrapolate = require('../extrapolator').extrapolate
 
 describe('extrapolate', () => {
-  context('when history is empty', () => {
-    const gasPriceHistory = []
-    it('throws', () => {
-      try {
-        extrapolate(gasPriceHistory)
-      } catch (error) {
-        assert.equal(error.message, 'Attempted to extrapolate with no data points')
-      }
-    })
-  })
+  const details = {
+    extrapolationHistory: 3
+  }
 
-  context('when history has only one data point', async () => {
-    const gasPriceHistory = [10 * 10 ** 9]
-    it('returns that one data point', async () => {
-      const extrapolatedGasPrice = extrapolate(gasPriceHistory)
-      assert.equal(extrapolatedGasPrice, gasPriceHistory[0])
-    })
-  })
+  it('extrapolates correctly', () => {
+    // Returns the current gas price if the history is empty
+    // History: []
+    let extrapolatedGasPrice = extrapolate(details, 10 * 10 ** 9)
+    assert.equal(extrapolatedGasPrice, 10 * 10 ** 9)
 
-  context('when there are increasing data points', () => {
-    const gasPriceHistory = [10 * 10 ** 9, 12 * 10 ** 9, 14 * 10 ** 9]
-    it('extrapolates correctly', () => {
-      const extrapolatedGasPrice = extrapolate(gasPriceHistory)
-      assert.equal(extrapolatedGasPrice, 16 * 10 ** 9)
-    })
-  })
+    // Still extrapolates if we have less than extrapolationHistory readings
+    // History: [10 gwei]
+    extrapolatedGasPrice = extrapolate(details, 12 * 10 ** 9)
+    assert.equal(extrapolatedGasPrice, 14 * 10 ** 9)
 
-  context('when there are decreasing data points', () => {
-    const gasPriceHistory = [14 * 10 ** 9, 12 * 10 ** 9, 10 * 10 ** 9]
-    it('extrapolates correctly', () => {
-      const extrapolatedGasPrice = extrapolate(gasPriceHistory)
-      assert.equal(extrapolatedGasPrice, 8 * 10 ** 9)
-    })
+    // Extrapolates correctly with extrapolationHistory-many readings
+    // History: [10 gwei, 12 gwei]
+    extrapolatedGasPrice = extrapolate(details, 14 * 10 ** 9)
+    assert.equal(extrapolatedGasPrice, 16 * 10 ** 9)
+
+    // Extrapolates correctly with decreasing values
+    extrapolate(details, 12 * 10 ** 9)
+    // History: [... 14 gwei, 12 gwei]
+    extrapolatedGasPrice = extrapolate(details, 10 * 10 ** 9)
+    assert.equal(extrapolatedGasPrice, 8 * 10 ** 9)
   })
 })

--- a/test/extrapolator_test.js
+++ b/test/extrapolator_test.js
@@ -14,7 +14,7 @@ describe('extrapolate', () => {
   })
 
   context('when history has only one data point', async () => {
-    const gasPriceHistory = [10 * 10**9]
+    const gasPriceHistory = [10 * 10 ** 9]
     it('returns that one data point', async () => {
       const extrapolatedGasPrice = extrapolate(gasPriceHistory)
       assert.equal(extrapolatedGasPrice, gasPriceHistory[0])
@@ -22,18 +22,18 @@ describe('extrapolate', () => {
   })
 
   context('when there are increasing data points', () => {
-    const gasPriceHistory = [10 * 10**9, 12 * 10**9, 14 * 10**9]
+    const gasPriceHistory = [10 * 10 ** 9, 12 * 10 ** 9, 14 * 10 ** 9]
     it('extrapolates correctly', () => {
-        const extrapolatedGasPrice = extrapolate(gasPriceHistory)
-        assert.equal(extrapolatedGasPrice, 16 * 10**9)
+      const extrapolatedGasPrice = extrapolate(gasPriceHistory)
+      assert.equal(extrapolatedGasPrice, 16 * 10 ** 9)
     })
   })
 
   context('when there are decreasing data points', () => {
-    const gasPriceHistory = [14 * 10**9, 12 * 10**9, 10 * 10**9]
+    const gasPriceHistory = [14 * 10 ** 9, 12 * 10 ** 9, 10 * 10 ** 9]
     it('extrapolates correctly', () => {
-        const extrapolatedGasPrice = extrapolate(gasPriceHistory)
-        assert.equal(extrapolatedGasPrice, 8 * 10**9)
+      const extrapolatedGasPrice = extrapolate(gasPriceHistory)
+      assert.equal(extrapolatedGasPrice, 8 * 10 ** 9)
     })
   })
 })


### PR DESCRIPTION
If the previous gas price readings were 10 gwei, 12 gwei and the current reading is 14 gwei, the node should use 16 gwei instead of 14 gwei to keep ahead of the trend. I did simple linear extrapolation to achieve that.